### PR TITLE
Add module documentation for agent files

### DIFF
--- a/browser_use/agent/execution.py
+++ b/browser_use/agent/execution.py
@@ -1,3 +1,11 @@
+# @file purpose: Execution helpers for interacting with the browser.
+"""Asynchronous routines for running actions and replaying history.
+
+These utilities support the :class:`Agent` by executing multiple actions
+per step, replaying stored interaction history and updating action
+indices when the DOM structure changes.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/browser_use/agent/main.py
+++ b/browser_use/agent/main.py
@@ -1,3 +1,11 @@
+# @file purpose: Core orchestration logic for the Browser Use agent.
+"""Implements the primary Agent class and supporting utilities.
+
+This module wires together browser sessions, planning, memory management
+and action execution. The :class:`Agent` coordinates these subsystems to
+solve tasks using a browser instance.
+"""
+
 import asyncio
 import gc
 import inspect

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1,3 +1,10 @@
+"""Compatibility layer exposing the :class:`Agent` for importers.
+
+Until the agent implementation is split into smaller modules, this file
+simply re-exports :class:`Agent` from ``main`` so existing imports
+continue to work.
+"""
+
 from .main import Agent
 
 __all__ = ["Agent"]


### PR DESCRIPTION
## Summary
- document the agent's main file
- document execution helpers
- document service stub module

## Testing
- `python -m py_compile browser_use/agent/main.py` *(fails: TabError)*
- `python -m py_compile browser_use/agent/execution.py`
- `python -m py_compile browser_use/agent/service.py`
- `ruff format browser_use/agent/main.py browser_use/agent/execution.py browser_use/agent/service.py` *(fails: Unexpected indentation)*

------
https://chatgpt.com/codex/tasks/task_e_685d72b665bc8329bc8bffc5b18a6287