### PR TITLE
Fix tests to use gpt-4o

### DIFF
--- a/browser_use/llm/tests/test_groq_loop.py
+++ b/browser_use/llm/tests/test_groq_loop.py
@@ -8,7 +8,7 @@ llm = ChatGroq(
 	model='meta-llama/llama-4-maverick-17b-128e-instruct',
 	temperature=0.5,
 )
-# llm = ChatOpenAI(model='gpt-4.1-mini')
+# llm = ChatOpenAI(model='gpt-4o-mini')
 
 
 async def main():

--- a/browser_use/llm/tests/test_single_step.py
+++ b/browser_use/llm/tests/test_single_step.py
@@ -130,7 +130,7 @@ async def test_single_step():
 	models: list[BaseChatModel] = [
 		ChatGroq(model='meta-llama/llama-4-maverick-17b-128e-instruct'),
 		ChatGoogle(model='gemini-2.0-flash-exp'),
-		ChatOpenAI(model='gpt-4.1'),
+                ChatOpenAI(model='gpt-4o'),
 		ChatAnthropic(model='claude-3-5-sonnet-latest'),  # Using haiku for cost efficiency
 		ChatAzureOpenAI(model='gpt-4o-mini'),
 	]

--- a/browser_use/tokens/tests/test_cost.py
+++ b/browser_use/tokens/tests/test_cost.py
@@ -28,8 +28,8 @@ Keep track of which countries you've already said and don't repeat them.
 Only output the country name, no numbers, no punctuation, just the name."""
 
 	# Test with different models
-	models = [
-		ChatOpenAI(model='gpt-4.1'),
+        models = [
+                ChatOpenAI(model='gpt-4o'),
 		# ChatGoogle(model='gemini-2.0-flash-exp'),
 	]
 

--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -61,8 +61,8 @@ async def run_single_task(task_file):
 		print(f'[DEBUG] Task: {task[:100]}...', file=sys.stderr)
 		print(f'[DEBUG] Max steps: {max_steps}', file=sys.stderr)
 
-		agent_llm = ChatOpenAI(model='gpt-4.1-mini')
-		judge_llm = ChatOpenAI(model='gpt-4.1-mini')
+                agent_llm = ChatOpenAI(model='gpt-4o-mini')
+                judge_llm = ChatOpenAI(model='gpt-4o-mini')
 		print('[DEBUG] LLMs initialized', file=sys.stderr)
 
 		# Each subprocess gets its own profile and session


### PR DESCRIPTION
## Summary
- replace deprecated gpt-4.1 model references with gpt-4o in the tests

## Testing
- `uv run pytest -vxs tests/ci` *(fails: Failed to fetch pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d744eeaf88329a7c35234de4a6bea