### PR TITLE
Implement BrowserPlanner and BrowserMemory

### DIFF
--- a/browser_use/agent/memory_adapter.py
+++ b/browser_use/agent/memory_adapter.py
@@ -2,9 +2,42 @@ from __future__ import annotations
 
 import logging
 
+import time
+
+from pydantic import BaseModel, Field
+
 from browser_use.agent.memory import Memory, MemoryConfig
 
 logger = logging.getLogger(__name__)
+	
+	
+	class MemoryEntry(BaseModel):
+	"""A single memory item stored in :class:`BrowserMemory`."""
+	
+	text: str
+	timestamp: float = Field(default_factory=lambda: time.time())
+	
+	
+class BrowserMemory:
+"""Simple in-memory storage for text snippets."""
+
+	def __init__(self) -> None:
+	self._entries: list[MemoryEntry] = []
+	self.logger = logger.getChild('BrowserMemory')
+	
+	def store(self, text: str) -> None:
+	"""Store a new memory entry."""
+	self._entries.append(MemoryEntry(text=text))
+	
+	def retrieve(self, limit: int | None = None) -> list[MemoryEntry]:
+	"""Retrieve the most recent memory entries."""
+	if limit is None:
+	return list(self._entries)
+	return self._entries[-limit:]
+	
+	def snapshot(self) -> list[MemoryEntry]:
+	"""Return a copy of all stored memories."""
+	return list(self._entries)
 
 
 def initialize_memory(agent) -> None:

--- a/browser_use/agent/planning.py
+++ b/browser_use/agent/planning.py
@@ -4,15 +4,98 @@ import json
 import logging
 import re
 
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
 from browser_use.agent.prompts import PlannerPrompt
 from browser_use.exceptions import LLMException
-from browser_use.llm.messages import UserMessage
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.messages import BaseMessage, UserMessage
 from browser_use.utils import time_execution_async
 
 logger = logging.getLogger(__name__)
 
 THINK_TAGS = re.compile(r'<think>.*?</think>', re.DOTALL)
 STRAY_CLOSE_TAG = re.compile(r'.*?</think>', re.DOTALL)
+
+
+class PlannerContext(BaseModel):
+"""Context information required for generating plans."""
+
+	model_config = ConfigDict(arbitrary_types_allowed=True)
+
+	llm: BaseChatModel = Field(description='LLM used to generate plans')
+	messages: list[BaseMessage] = Field(default_factory=list, description='Message history to provide as context')
+	available_actions: str = Field(default='', description='Actions the agent can take')
+	is_planner_reasoning: bool = Field(default=False, description='Use chain-of-thought style planner reasoning')
+	extend_planner_system_message: str | None = Field(default=None, description='Additional system prompt text')
+	use_vision_for_planner: bool = Field(default=True, description='Allow images to be sent to the planner LLM')
+	use_vision: bool = Field(default=False, description='Whether image messages are included in messages')
+
+
+class Plan(BaseModel):
+"""Structured plan returned by :class:`BrowserPlanner`."""
+	
+	state_analysis: str | None = None
+	progress_evaluation: str | None = None
+	challenges: str | None = None
+	next_steps: str | None = None
+	reasoning: str | None = None
+raw: str = Field(description='Raw plan text returned by the LLM')
+
+
+class BrowserPlanner:
+	"""Utility for generating high level plans."""
+	
+	def __init__(self, llm: BaseChatModel, *, logger: logging.Logger | None = None):
+	self.llm = llm
+	self.logger = logger or logging.getLogger(__name__)
+	
+	async def generate_plan(self, task: str, *, context: PlannerContext) -> Plan:
+	"""Generate a plan for ``task`` using the provided context."""
+	messages = [
+	PlannerPrompt(context.available_actions).get_system_message(
+	is_planner_reasoning=context.is_planner_reasoning,
+	extended_planner_system_prompt=context.extend_planner_system_message,
+	),
+	*context.messages,
+	]
+	
+	if not context.use_vision_for_planner and context.use_vision and messages:
+	last_state_message: UserMessage = messages[-1]  # type: ignore[assignment]
+	new_msg = ''
+	if isinstance(last_state_message.content, list):
+	for msg in last_state_message.content:
+	if msg.type == 'text':
+	new_msg += msg.text
+	else:
+	new_msg = last_state_message.content  # type: ignore[assignment]
+	messages[-1] = UserMessage(content=new_msg)
+	
+	try:
+	response = await self.llm.ainvoke(messages)
+	except Exception as e:
+	status_code = getattr(e, 'status_code', None) or getattr(e, 'code', None) or 500
+	self.logger.error(f'Failed to invoke planner: {e}')
+	raise LLMException(status_code, f'Planner LLM API call failed: {type(e).__name__}: {e}') from e
+	
+	plan_str = response.completion
+	if 'deepseek-r1' in self.llm.model or 'deepseek-reasoner' in self.llm.model:
+	plan_str = _remove_think_tags(self, plan_str)
+	
+	parsed: dict[str, Any] | None = None
+	try:
+	parsed = json.loads(plan_str)
+	self.logger.info(f'Planning Analysis:\n{json.dumps(parsed, indent=4)}')
+	except json.JSONDecodeError:
+	self.logger.info(f'Planning Analysis:\n{plan_str}')
+	except Exception as e:
+	self.logger.debug(f'Error parsing planning analysis: {e}')
+	self.logger.info(f'Plan: {plan_str}')
+	
+	plan_data = parsed if isinstance(parsed, dict) else {}
+	return Plan(raw=plan_str, **plan_data)
 
 
 def _remove_think_tags(self, text: str) -> str:


### PR DESCRIPTION
## Summary
- add BrowserPlanner with plan generation logic
- add BrowserMemory with simple storage

## Testing
- `uv pip install --system pyright` *(fails: Request failed)*
- `uv run pytest -q tests/ci` *(fails: Failed to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d745619c08329ab8d01de84c3121e