### PR TITLE
Add agentic OS config loader

### DIFF
--- a/agentic_os.yaml
+++ b/agentic_os.yaml
@@ -1,0 +1,3 @@
+planner_model: gpt-4o
+memory_backend: vector_db
+toolhub_endpoint: https://toolhub.example.com

--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -1,4 +1,5 @@
 from browser_use.logging_config import setup_logging
+from browser_use.agentic_os import AGENTIC_OS_CONFIG
 
 logger = setup_logging()
 
@@ -35,9 +36,9 @@ base_subprocess.BaseSubprocessTransport.__del__ = _patched_del
 
 
 __all__ = [
-	'Agent',
-	'Browser',
-	'BrowserConfig',
+        'Agent',
+        'Browser',
+        'BrowserConfig',
 	'BrowserSession',
 	'BrowserProfile',
 	'Controller',
@@ -47,5 +48,6 @@ __all__ = [
 	'ActionModel',
 	'AgentHistoryList',
 	'BrowserContext',
-	'BrowserContextConfig',
+        'BrowserContextConfig',
+        'AGENTIC_OS_CONFIG',
 ]

--- a/browser_use/agentic_os.py
+++ b/browser_use/agentic_os.py
@@ -1,0 +1,33 @@
+"""Loader for agentic OS configuration."""
+
+import os
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+
+class AgenticOSConfig(BaseModel):
+	"""Settings loaded from ``agentic_os.yaml``."""
+
+	planner_model: str | None = None
+	memory_backend: str | None = None
+	toolhub_endpoint: str | None = None
+
+
+DEFAULT_CONFIG_PATH = Path(os.getenv('AGENTIC_OS_CONFIG', 'agentic_os.yaml'))
+
+
+def load_agentic_os_config(path: str | Path | None = None) -> AgenticOSConfig:
+	"""Load agentic OS settings from a YAML file."""
+	cfg_path = Path(path) if path else DEFAULT_CONFIG_PATH
+	if not cfg_path.is_file():
+	    return AgenticOSConfig()
+	with cfg_path.open() as f:
+	    data = yaml.safe_load(f) or {}
+	if not isinstance(data, dict):
+	    return AgenticOSConfig()
+	return AgenticOSConfig(**data)
+
+
+AGENTIC_OS_CONFIG = load_agentic_os_config()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pyobjc>=11.0; platform_system == 'darwin'",
     "pyperclip>=1.9.0",
     "python-dotenv>=1.0.1",
+    "pyyaml>=6.0",
     "requests>=2.32.3",
     "screeninfo>=0.8.1; platform_system != 'darwin'",
     "typing-extensions>=4.12.2",

--- a/tests/ci/test_agentic_os_loader.py
+++ b/tests/ci/test_agentic_os_loader.py
@@ -1,0 +1,19 @@
+"""Tests for agentic OS configuration loader."""
+
+from browser_use.agentic_os import load_agentic_os_config
+
+
+class TestAgenticOSLoader:
+	def test_load_from_path(self, tmp_path):
+	    cfg = tmp_path / "cfg.yaml"
+	    cfg.write_text("planner_model: foo\nmemory_backend: bar\n")
+	    loaded = load_agentic_os_config(cfg)
+	    assert loaded.planner_model == "foo"
+	    assert loaded.memory_backend == "bar"
+
+	def test_env_variable_path(self, tmp_path, monkeypatch):
+	    cfg = tmp_path / "env.yaml"
+	    cfg.write_text("toolhub_endpoint: http://x.com\n")
+	    monkeypatch.setenv("AGENTIC_OS_CONFIG", str(cfg))
+	    loaded = load_agentic_os_config()
+	    assert loaded.toolhub_endpoint == "http://x.com"


### PR DESCRIPTION
## Summary
- create `agentic_os.yaml` with default settings
- implement loader for Agentic OS YAML config
- expose loader through `browser_use.__init__`
- depend on `pyyaml`
- test the loader behaviour

## Testing
- `uv run pyright` *(fails: unsuccessful tunnel to pypi.org)*
- `uv run pytest -vxs tests/ci` *(fails: unsuccessful tunnel to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d781fdaf48329a4af828a6c97449e