### PR TITLE
Add module docs

### DIFF
--- a/agentic_os/__init__.py
+++ b/agentic_os/__init__.py
@@ -1,3 +1,6 @@
+# @file purpose: Public API for the agentic OS tool registry.
+"""Exports tool specifications and registry helpers."""
+
 from .tools import ToolSpec, get_registry, register_spec
 
-__all__ = ["ToolSpec", "register_spec", "get_registry"]
+__all__ = ['ToolSpec', 'register_spec', 'get_registry']

--- a/browser_use/agent/memory_adapter.py
+++ b/browser_use/agent/memory_adapter.py
@@ -1,3 +1,6 @@
+# @file purpose: Memory initialization helpers and in-memory store for agents.
+"""Provides a simple text memory cache and setup utilities."""
+
 from __future__ import annotations
 
 import logging

--- a/browser_use/agent/planning.py
+++ b/browser_use/agent/planning.py
@@ -1,3 +1,6 @@
+# @file purpose: Planning utilities for the Browser Use agent.
+"""Generates high level plans and related context."""
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- add missing file purpose comments and module docstrings to memory_adapter, planning, and agentic_os packages

## Testing
- `ruff check agentic_os/__init__.py`
- `python -m py_compile agentic_os/__init__.py`
- `ruff check browser_use/agent/memory_adapter.py browser_use/agent/planning.py agentic_os/__init__.py` *(fails: SyntaxError)*
- `python -m py_compile browser_use/agent/planning.py` *(fails: IndentationError)*
- `python -m py_compile browser_use/agent/memory_adapter.py` *(fails: IndentationError)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685d8384a7888329bf0d9c659670e041