### PR TITLE
Implement async memory store interface

### DIFF
--- a/agentic_os/__init__.py
+++ b/agentic_os/__init__.py
@@ -1,3 +1,4 @@
 from .tools import ToolSpec, get_registry, register_spec
+from .memory import MemoryStore
 
-__all__ = ["ToolSpec", "register_spec", "get_registry"]
+__all__ = ["ToolSpec", "register_spec", "get_registry", "MemoryStore"]

--- a/agentic_os/memory.py
+++ b/agentic_os/memory.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Protocol, Any, runtime_checkable
+
+
+@runtime_checkable
+class MemoryStore(Protocol):
+    async def store(self, text: str) -> None: ...
+
+    async def retrieve(self, limit: int | None = None) -> list[Any]: ...
+
+    async def snapshot(self) -> list[Any]: ...

--- a/browser_use/agent/memory_adapter.py
+++ b/browser_use/agent/memory_adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-
 import time
 
 from pydantic import BaseModel, Field
@@ -9,35 +8,35 @@ from pydantic import BaseModel, Field
 from browser_use.agent.memory import Memory, MemoryConfig
 
 logger = logging.getLogger(__name__)
-	
-	
-	class MemoryEntry(BaseModel):
-	"""A single memory item stored in :class:`BrowserMemory`."""
-	
-	text: str
-	timestamp: float = Field(default_factory=lambda: time.time())
-	
-	
-class BrowserMemory:
-"""Simple in-memory storage for text snippets."""
 
-	def __init__(self) -> None:
-	self._entries: list[MemoryEntry] = []
-	self.logger = logger.getChild('BrowserMemory')
-	
-	def store(self, text: str) -> None:
-	"""Store a new memory entry."""
-	self._entries.append(MemoryEntry(text=text))
-	
-	def retrieve(self, limit: int | None = None) -> list[MemoryEntry]:
-	"""Retrieve the most recent memory entries."""
-	if limit is None:
-	return list(self._entries)
-	return self._entries[-limit:]
-	
-	def snapshot(self) -> list[MemoryEntry]:
-	"""Return a copy of all stored memories."""
-	return list(self._entries)
+
+class MemoryEntry(BaseModel):
+    """A single memory item stored in :class:`BrowserMemory`."""
+
+    text: str
+    timestamp: float = Field(default_factory=lambda: time.time())
+
+
+class BrowserMemory:
+    """Simple in-memory storage for text snippets."""
+
+    def __init__(self) -> None:
+        self._entries: list[MemoryEntry] = []
+        self.logger = logger.getChild('BrowserMemory')
+
+    async def store(self, text: str) -> None:
+        """Store a new memory entry."""
+        self._entries.append(MemoryEntry(text=text))
+
+    async def retrieve(self, limit: int | None = None) -> list[MemoryEntry]:
+        """Retrieve the most recent memory entries."""
+        if limit is None:
+            return list(self._entries)
+        return self._entries[-limit:]
+
+    async def snapshot(self) -> list[MemoryEntry]:
+        """Return a copy of all stored memories."""
+        return list(self._entries)
 
 
 def initialize_memory(agent) -> None:

--- a/tests/ci/test_browser_memory.py
+++ b/tests/ci/test_browser_memory.py
@@ -1,0 +1,21 @@
+import pytest
+
+from browser_use.agent.memory_adapter import BrowserMemory
+
+
+class TestBrowserMemory:
+    async def test_store_and_retrieve(self):
+        mem = BrowserMemory()
+        await mem.store('one')
+        await mem.store('two')
+        all_entries = await mem.retrieve()
+        assert [e.text for e in all_entries] == ['one', 'two']
+        latest = await mem.retrieve(limit=1)
+        assert [e.text for e in latest] == ['two']
+
+    async def test_snapshot(self):
+        mem = BrowserMemory()
+        await mem.store('a')
+        snap = await mem.snapshot()
+        assert len(snap) == 1
+        assert snap[0].text == 'a'


### PR DESCRIPTION
## Summary
- add `MemoryStore` protocol for async memory adapters
- expose `MemoryStore` in `agentic_os.__init__`
- convert `BrowserMemory` methods to async
- test async `BrowserMemory` behavior

## Testing
- `uv pip install -e .` *(fails: Failed to fetch)*
- `uv run pytest -q tests/ci/test_browser_memory.py` *(fails: Failed to fetch)*
- `uv run pyright` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_685d8395bfbc8329b49f6f3afa360748