### PR TITLE
Expose browser_use via agentic_os and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Spin up your agent:
 import asyncio
 from dotenv import load_dotenv
 load_dotenv()
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 async def main():
     agent = Agent(

--- a/agentic_os/browser_use/__init__.py
+++ b/agentic_os/browser_use/__init__.py
@@ -1,0 +1,24 @@
+"""Compatibility wrapper for the ``browser_use`` package.
+
+This module exposes the public API of :mod:`browser_use` under
+``agentic_os.browser_use`` so existing code can migrate seamlessly.
+"""
+
+import browser_use
+from browser_use import *  # noqa: F401,F403
+from browser_use.agent.planning import BrowserPlanner, Plan, PlannerContext
+from browser_use.agent.memory_adapter import (
+    BrowserMemory,
+    initialize_memory,
+    maybe_create_procedural_memory,
+)
+
+__all__ = [
+    *browser_use.__all__,  # type: ignore[name-defined]
+    "BrowserPlanner",
+    "Plan",
+    "PlannerContext",
+    "BrowserMemory",
+    "initialize_memory",
+    "maybe_create_procedural_memory",
+]

--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -11,8 +11,8 @@ The `Agent` class is the core component of Browser Use that handles browser auto
 ## Basic Settings
 
 ```python
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 agent = Agent(
     task="Search for latest news about AI",
@@ -177,7 +177,7 @@ agent = Agent(
 You can configure the agent and provide a separate message to help the LLM understand the task better.
 
 ```python
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.llm import ChatOpenAI
 
 agent = Agent(
     task="your task",
@@ -191,7 +191,7 @@ agent = Agent(
 You can configure the agent to use a separate planner model for high-level task planning:
 
 ```python
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Initialize models
 llm = ChatOpenAI(model='gpt-4o')
@@ -237,7 +237,7 @@ Using a separate planner model can help:
 Browser Use includes a procedural memory system using [Mem0](https://mem0.ai) that automatically summarizes the agent's conversation history at regular intervals to optimize context window usage during long tasks.
 
 ```python
-from browser_use.agent.memory import MemoryConfig
+from agentic_os.browser_use.agent.memory import MemoryConfig
 
 agent = Agent(
     task="your task",
@@ -261,8 +261,8 @@ agent = Agent(
 You must configure the memory system using the `MemoryConfig` Pydantic model for a type-safe approach:
 
 ```python
-from browser_use.agent.memory import MemoryConfig
-from browser_use.llm import ChatOpenAI # Assuming llm is an instance of ChatOpenAI
+from agentic_os.browser_use.agent.memory import MemoryConfig
+from agentic_os.browser_use.llm import ChatOpenAI # Assuming llm is an instance of ChatOpenAI
 
 llm_for_agent = ChatOpenAI(model="gpt-4o")
 

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -11,7 +11,7 @@ Browser Use uses [playwright](https://playwright.dev/python/docs/api/class-brows
 **To launch or connect to a browser**, pass any playwright / browser-use configuration arguments you want to `BrowserSession(...)`:
 
 ```python
-from browser_use import BrowserSession, Agent
+from agentic_os.browser_use import BrowserSession, Agent
 
 browser_session = BrowserSession(
     headless=True,
@@ -213,7 +213,7 @@ The only parameters `BrowserProfile` can NOT take are the session-specific conne
 ### Basic Example
 
 ```python
-from browser_use.browser import BrowserProfile
+from agentic_os.browser_use.browser import BrowserProfile
 
 profile = BrowserProfile(
     stealth=True,
@@ -949,7 +949,7 @@ Whether playwright should swallow SIGTERM signals and kill the browser.
 ## Full Example
 
 ```python
-from browser_use import BrowserSession, BrowserProfile, Agent
+from agentic_os.browser_use import BrowserSession, BrowserProfile, Agent
 
 browser_profile = BrowserProfile(
     headless=False,

--- a/docs/customize/custom-functions.mdx
+++ b/docs/customize/custom-functions.mdx
@@ -21,7 +21,7 @@ For examples of custom actions (e.g. uploading files, asking a human-in-the-loop
 To register your own custom functions (which can be `sync` or `async`), decorate them with the `@controller.action(...)` decorator. This saves them into the `controller.registry`.
 
 ```python
-from browser_use import Controller, ActionResult
+from agentic_os.browser_use import Controller, ActionResult
 
 controller = Controller()
 
@@ -80,7 +80,7 @@ The LLM gets the entire pydantic JSON schema for your `param_model`, it will see
 ```python
 from typing import Annotated
 from pydantic import BaseModel, AfterValidator
-from browser_use import ActionResult
+from agentic_os.browser_use import ActionResult
 
 class MyParams(BaseModel):
     field1: int
@@ -117,7 +117,7 @@ For example, actions that need to run playwright code to interact with the brows
 
 ```python
 from playwright.async_api import Page
-from browser_use import Controller, ActionResult
+from agentic_os.browser_use import Controller, ActionResult
 
 controller = Controller()
 
@@ -130,7 +130,7 @@ async def input_text_into_page(text: str, page: Page) -> ActionResult:
 #### Example: Action uses the `browser_context`
 
 ```python
-from browser_use import BrowserSession, Controller, ActionResult
+from agentic_os.browser_use import BrowserSession, Controller, ActionResult
 
 controller = Controller()
 
@@ -233,7 +233,7 @@ If you want actions to only be available on certain pages, and to not tell the L
 
 ```python
 from pydantic import BaseModel
-from browser_use import Controller, ActionResult
+from agentic_os.browser_use import Controller, ActionResult
 
 controller = Controller()
 

--- a/docs/customize/hooks.mdx
+++ b/docs/customize/hooks.mdx
@@ -26,8 +26,8 @@ Each hook should be an `async` callable function that accepts the `agent` instan
 ### Basic Example
 
 ```python
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 async def my_step_hook(agent: Agent):
@@ -232,8 +232,8 @@ import asyncio
 import requests
 from dotenv import load_dotenv
 from pyobjtojson import obj_to_json
-from browser_use.llm import ChatOpenAI
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
 
 # Load environment variables (for API keys)
 load_dotenv()

--- a/docs/customize/real-browser.mdx
+++ b/docs/customize/real-browser.mdx
@@ -27,7 +27,7 @@ We provide automatic CAPTCHA solving, proxies, human-in-the-loop automation, and
 Launch a local browser using built-in default (playwright `chromium`) or a provided `executable_path`:
 
 ```python
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use import Agent, BrowserSession
 
 # If no executable_path provided, uses Playwright/Patchright's built-in Chromium
 browser_session = BrowserSession(
@@ -68,7 +68,7 @@ We support most `chromium`-based browsers in `executable_path`, including [Brave
 Pass existing Playwright `Page`, `BrowserContext`, `Browser`, and/or `playwright` API object to `BrowserSession(...)`:
 
 ```python
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use import Agent, BrowserSession
 from playwright.async_api import async_playwright
 # from patchright.async_api import async_playwright   # stealth alternative
 
@@ -106,7 +106,7 @@ agent = Agent(
 Connect to a browser with open `--remote-debugging-port`:
 
 ```python
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use import Agent, BrowserSession
 
 # First, start Chrome with remote debugging:
 # /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=9242
@@ -126,7 +126,7 @@ agent = Agent(
 Connect to Playwright Node.js server providers:
 
 ```python
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use import Agent, BrowserSession
 
 # Connect to a playwright server
 browser_session = BrowserSession(wss_url="wss://your-playwright-server.com/ws")
@@ -143,7 +143,7 @@ agent = Agent(
 Connect to any remote Chromium-based browser:
 
 ```python
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use import Agent, BrowserSession
 
 # Connect to Chrome via CDP
 browser_session = BrowserSession(cdp_url="http://localhost:9222")
@@ -225,8 +225,8 @@ Browser Use provides a number of ways to re-use profiles, sessions, and other co
 If you are only running one agent & browser at a time, they can re-use the same `user_data_dir` sequentially.
 
 ```python
-from browser_use import Agent, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 reused_profile = BrowserProfile(user_data_dir='~/.config/browseruse/profiles/default')
 
@@ -253,8 +253,8 @@ If you are only running one agent at a time, they can re-use the same active `Br
 Each agent will start off looking at the same tab the last agent ended off on.
 
 ```python
-from browser_use import Agent, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 reused_session = BrowserSession(
     user_data_dir='~/.config/browseruse/profiles/default',
@@ -282,8 +282,8 @@ await reused_session.close()
 ### Parallel Agents, Same Browser, Multiple Tabs
 
 ```python
-from browser_use import Agent, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 shared_browser = BrowserSession(
     storage_state='/tmp/cookies.json',
@@ -317,8 +317,8 @@ await shared_browser.close()
 </Warning>
 
 ```python
-from browser_use import Agent, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 from playwright.async_api import async_playwright
 
 playwright = await async_playwright().start()
@@ -360,7 +360,7 @@ playwright open https://example.com/ --load-storage=/tmp/auth.json
 ```
 
 ```python
-from browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
 
 shared_profile = BrowserProfile(
     headless=True,

--- a/docs/customize/sensitive-data.mdx
+++ b/docs/customize/sensitive-data.mdx
@@ -34,8 +34,8 @@ Here's a basic example of how to use sensitive data:
 from dotenv import load_dotenv
 load_dotenv()
 
-from browser_use.llm import ChatOpenAI
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, BrowserSession
 
 llm = ChatOpenAI(model='gpt-4.1')
 
@@ -150,8 +150,8 @@ Here's a more complex example demonstrating multiple domains and sensitive data 
 from dotenv import load_dotenv
 load_dotenv()
 
-from browser_use.llm import ChatOpenAI
-from browser_use import Agent, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, BrowserSession
 
 
 llm = ChatOpenAI(model='gpt-4.1')

--- a/docs/customize/supported-models.mdx
+++ b/docs/customize/supported-models.mdx
@@ -10,7 +10,7 @@ Here's how to configure the models.
 
 ### Migration from Langchain
 
-We have recently switched from Langchain to our own implementation of the models. To migrate the previous code, just replace `from langchain_openai import ChatOpenAI` with `from browser_use.llm import ChatOpenAI` etc. The methods should be compatible(ish).
+We have recently switched from Langchain to our own implementation of the models. To migrate the previous code, just replace `from langchain_openai import ChatOpenAI` with `from agentic_os.browser_use.llm import ChatOpenAI` etc. The methods should be compatible(ish).
 
 ## Model Recommendations
 
@@ -35,8 +35,8 @@ We have natively switched to structured output when possible,
 OpenAI's GPT-4.1 models are recommended for best performance.
 
 ```python
-from browser_use.llm import ChatOpenAI
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
 
 # Initialize the model
 llm = ChatOpenAI(
@@ -59,8 +59,8 @@ OPENAI_API_KEY=
 ### Anthropic
 
 ```python
-from browser_use.llm import ChatAnthropic
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatAnthropic
+from agentic_os.browser_use import Agent
 
 # Initialize the model
 llm = ChatAnthropic(
@@ -83,8 +83,8 @@ ANTHROPIC_API_KEY=
 ### Azure OpenAI
 
 ```python
-from browser_use.llm import ChatAzureOpenAI
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatAzureOpenAI
+from agentic_os.browser_use import Agent
 from pydantic import SecretStr
 import os
 
@@ -112,8 +112,8 @@ AZURE_OPENAI_API_KEY=
 > [!IMPORTANT] `GEMINI_API_KEY` was the old environment var name, it should be called `GOOGLE_API_KEY` as of 2025-05.
 
 ```python
-from browser_use.llm import ChatGoogle
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent
 from dotenv import load_dotenv
 
 # Read GOOGLE_API_KEY into env
@@ -138,8 +138,8 @@ GOOGLE_API_KEY=
 ## Groq
 
 ```python
-from browser_use.llm import ChatGroq
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatGroq
+from agentic_os.browser_use import Agent
 
 llm = ChatGroq(model="meta-llama/llama-4-maverick-17b-128e-instruct")
 

--- a/docs/development/observability.mdx
+++ b/docs/development/observability.mdx
@@ -33,8 +33,8 @@ export LMNR_PROJECT_API_KEY=<your-project-api-key>
 Then, you simply initialize the Laminar at the top of your project and both Browser Use and session recordings will be automatically traced.
 
 ```python {5-8}
-from browser_use.llm import ChatOpenAI
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
 import asyncio
 
 from lmnr import Laminar

--- a/docs/migration-to-agentic-os.md
+++ b/docs/migration-to-agentic-os.md
@@ -1,0 +1,17 @@
+# Migrating to `agentic_os`
+
+The `browser_use` package can now be accessed as `agentic_os.browser_use`.
+Existing imports such as:
+
+```python
+from browser_use import Agent
+```
+
+should be updated to:
+
+```python
+from agentic_os.browser_use import Agent
+```
+
+The previous `browser_use` namespace remains available for backward
+compatibility, so existing code will continue to run without changes.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -43,8 +43,8 @@ uv run playwright install
 Then you can use the agent as follows:
 
 ```python agent.py
-from browser_use.llm import ChatOpenAI
-from browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
 from dotenv import load_dotenv
 load_dotenv()
 

--- a/examples/browser/multiple_agents_same_browser.py
+++ b/examples/browser/multiple_agents_same_browser.py
@@ -9,10 +9,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.browser.profile import BrowserProfile
-from browser_use.browser.session import BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser.profile import BrowserProfile
+from agentic_os.browser_use.browser.session import BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 async def main():

--- a/examples/browser/real_browser.py
+++ b/examples/browser/real_browser.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 browser_profile = BrowserProfile(
 	# NOTE: you need to close your chrome browser - so that this can open your browser in debug mode

--- a/examples/browser/stealth.py
+++ b/examples/browser/stealth.py
@@ -13,10 +13,10 @@ load_dotenv()
 
 from imgcat import imgcat
 
-from browser_use.browser import BrowserSession
-from browser_use.browser.profile import BrowserProfile
-from browser_use.browser.types import async_patchright
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.browser.profile import BrowserProfile
+from agentic_os.browser_use.browser.types import async_patchright
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o')
 

--- a/examples/browser/using_cdp.py
+++ b/examples/browser/using_cdp.py
@@ -22,9 +22,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent, Controller
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatGoogle
 
 api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:

--- a/examples/browser/window_sizing.py
+++ b/examples/browser/window_sizing.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
 
 
 async def example_custom_window_size():

--- a/examples/custom-functions/2fa.py
+++ b/examples/custom-functions/2fa.py
@@ -11,8 +11,8 @@ load_dotenv()
 
 import pyotp  # type: ignore
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/examples/custom-functions/action_filters.py
+++ b/examples/custom-functions/action_filters.py
@@ -27,10 +27,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use.agent.service import Agent, Controller
-from browser_use.browser import BrowserSession
-from browser_use.browser.types import Page
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.agent.service import Agent, Controller
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.browser.types import Page
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Initialize controller and registry
 controller = Controller()

--- a/examples/custom-functions/advanced_search.py
+++ b/examples/custom-functions/advanced_search.py
@@ -14,9 +14,9 @@ import logging
 
 from pydantic import BaseModel
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.browser.profile import BrowserProfile
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.browser.profile import BrowserProfile
+from agentic_os.browser_use.llm import ChatOpenAI
 
 logger = logging.getLogger(__name__)
 

--- a/examples/custom-functions/clipboard.py
+++ b/examples/custom-functions/clipboard.py
@@ -10,11 +10,11 @@ load_dotenv()
 
 import pyperclip
 
-from browser_use import Agent, Controller
-from browser_use.agent.views import ActionResult
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.browser.types import Page
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.agent.views import ActionResult
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.browser.types import Page
+from agentic_os.browser_use.llm import ChatOpenAI
 
 browser_profile = BrowserProfile(
 	headless=False,

--- a/examples/custom-functions/custom_hooks_before_after_step.py
+++ b/examples/custom-functions/custom_hooks_before_after_step.py
@@ -125,8 +125,8 @@ load_dotenv()
 import requests
 from pyobjtojson import obj_to_json  # type: ignore
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # import prettyprinter
 # prettyprinter.install_extras()

--- a/examples/custom-functions/extract_pdf_content.py
+++ b/examples/custom-functions/extract_pdf_content.py
@@ -19,10 +19,10 @@ import logging
 from mistralai import Mistral  # type: ignore
 from pydantic import BaseModel, Field
 
-from browser_use import Agent, Controller
-from browser_use.agent.views import ActionResult
-from browser_use.browser.context import BrowserContext
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.agent.views import ActionResult
+from agentic_os.browser_use.browser.context import BrowserContext
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/custom-functions/file_upload.py
+++ b/examples/custom-functions/file_upload.py
@@ -17,10 +17,10 @@ try:
 except Exception:
 	pass
 
-from browser_use import Agent, Controller
-from browser_use.agent.views import ActionResult
-from browser_use.browser import BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.agent.views import ActionResult
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 logger = logging.getLogger(__name__)
 

--- a/examples/custom-functions/hover_element.py
+++ b/examples/custom-functions/hover_element.py
@@ -10,10 +10,10 @@ load_dotenv()
 
 from pydantic import BaseModel
 
-from browser_use import Agent, Controller
-from browser_use.agent.views import ActionResult
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.agent.views import ActionResult
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 class HoverAction(BaseModel):

--- a/examples/custom-functions/notification.py
+++ b/examples/custom-functions/notification.py
@@ -8,8 +8,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 controller = Controller()
 

--- a/examples/custom-functions/onepassword_2fa.py
+++ b/examples/custom-functions/onepassword_2fa.py
@@ -11,8 +11,8 @@ load_dotenv()
 
 from onepassword.client import Client  # type: ignore  # pip install onepassword-sdk
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/examples/custom-functions/perplexity_search.py
+++ b/examples/custom-functions/perplexity_search.py
@@ -12,9 +12,9 @@ import logging
 
 from pydantic import BaseModel
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.browser.profile import BrowserProfile
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.browser.profile import BrowserProfile
+from agentic_os.browser_use.llm import ChatOpenAI
 
 logger = logging.getLogger(__name__)
 

--- a/examples/custom-functions/save_to_file_hugging_face.py
+++ b/examples/custom-functions/save_to_file_hugging_face.py
@@ -10,9 +10,9 @@ load_dotenv()
 
 from pydantic import BaseModel
 
-from browser_use.agent.service import Agent
-from browser_use.controller.service import Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.controller.service import Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Initialize controller first
 controller = Controller()

--- a/examples/custom-functions/solve_amazon_captcha.py
+++ b/examples/custom-functions/solve_amazon_captcha.py
@@ -10,11 +10,11 @@ load_dotenv()
 
 from amazoncaptcha import AmazonCaptcha  # type: ignore
 
-from browser_use import ActionResult
-from browser_use.agent.service import Agent
-from browser_use.browser import BrowserConfig, BrowserSession
-from browser_use.controller.service import Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.browser import BrowserConfig, BrowserSession
+from agentic_os.browser_use.controller.service import Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 browser_profile = BrowserConfig(headless=False)
 

--- a/examples/features/click_fallback_options.py
+++ b/examples/features/click_fallback_options.py
@@ -10,8 +10,8 @@ load_dotenv()
 
 from aiohttp import web  # make sure to install aiohttp: pip install aiohttp
 
-from browser_use import Agent, Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Define a simple HTML page
 HTML_CONTENT = """

--- a/examples/features/cross_origin_iframes.py
+++ b/examples/features/cross_origin_iframes.py
@@ -14,9 +14,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent, Controller
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/features/custom_output.py
+++ b/examples/features/custom_output.py
@@ -16,8 +16,8 @@ load_dotenv()
 
 from pydantic import BaseModel
 
-from browser_use import Agent, Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 class Post(BaseModel):

--- a/examples/features/custom_system_prompt.py
+++ b/examples/features/custom_system_prompt.py
@@ -9,8 +9,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 extend_system_message = (
 	'REMEMBER the most important RULE: ALWAYS open first a new tab and go first to url wikipedia.com no matter the task!!!'

--- a/examples/features/custom_user_agent.py
+++ b/examples/features/custom_user_agent.py
@@ -9,10 +9,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.controller.service import Controller
-from browser_use.llm import ChatAnthropic, ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.controller.service import Controller
+from agentic_os.browser_use.llm import ChatAnthropic, ChatOpenAI
 
 
 def get_llm(provider: str):

--- a/examples/features/download_file.py
+++ b/examples/features/download_file.py
@@ -9,9 +9,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.browser import BrowserSession
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.llm import ChatGoogle
 
 api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:
@@ -20,7 +20,7 @@ if not api_key:
 assert api_key is not None, 'GOOGLE_API_KEY must be set'
 llm = ChatGoogle(model='gemini-2.0-flash-exp', api_key=api_key)
 
-from browser_use.browser import BrowserProfile
+from agentic_os.browser_use.browser import BrowserProfile
 
 browser_session = BrowserSession(
 	browser_profile=BrowserProfile(

--- a/examples/features/drag_drop.py
+++ b/examples/features/drag_drop.py
@@ -9,8 +9,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatGoogle
 
 api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:

--- a/examples/features/follow_up_tasks.py
+++ b/examples/features/follow_up_tasks.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent, Controller
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Initialize the model
 llm = ChatOpenAI(

--- a/examples/features/initial_actions.py
+++ b/examples/features/initial_actions.py
@@ -8,8 +8,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o')
 

--- a/examples/features/multi-tab_handling.py
+++ b/examples/features/multi-tab_handling.py
@@ -14,8 +14,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # video: https://preview.screen.studio/share/clenCmS6
 llm = ChatOpenAI(model='gpt-4o')

--- a/examples/features/multiple_tasks.py
+++ b/examples/features/multiple_tasks.py
@@ -9,10 +9,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.browser import BrowserSession
-from browser_use.browser.types import async_playwright
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.browser.types import async_playwright
+from agentic_os.browser_use.llm import ChatGoogle
 
 api_key = os.getenv('GOOGLE_API_KEY')
 

--- a/examples/features/outsource_state.py
+++ b/examples/features/outsource_state.py
@@ -16,10 +16,10 @@ load_dotenv()
 
 import anyio
 
-from browser_use import Agent
-from browser_use.agent.views import AgentState
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.agent.views import AgentState
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 async def main():

--- a/examples/features/parallel_agents.py
+++ b/examples/features/parallel_agents.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use.agent.service import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 browser_session = BrowserSession(
 	browser_profile=BrowserProfile(

--- a/examples/features/pause_agent.py
+++ b/examples/features/pause_agent.py
@@ -9,8 +9,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 class AgentController:

--- a/examples/features/planner.py
+++ b/examples/features/planner.py
@@ -8,8 +8,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o', temperature=0.0)
 planner_llm = ChatOpenAI(

--- a/examples/features/restrict_urls.py
+++ b/examples/features/restrict_urls.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o', temperature=0.0)
 task = (

--- a/examples/features/result_processing.py
+++ b/examples/features/result_processing.py
@@ -9,10 +9,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.agent.views import AgentHistoryList
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.agent.views import AgentHistoryList
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o')
 

--- a/examples/features/save_trace.py
+++ b/examples/features/save_trace.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use.agent.service import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o', temperature=0.0)
 

--- a/examples/features/sensitive_data.py
+++ b/examples/features/sensitive_data.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Initialize the model
 llm = ChatOpenAI(
@@ -38,7 +38,7 @@ sensitive_data: dict[str, str | dict[str, str]] = {
 task = 'Go to example.com and login with company_username and company_password'
 
 # Always set allowed_domains when using sensitive_data for security
-from browser_use.browser.session import BrowserSession
+from agentic_os.browser_use.browser.session import BrowserSession
 
 browser_session = BrowserSession(
 	browser_profile=BrowserProfile(

--- a/examples/features/small_model_for_extraction.py
+++ b/examples/features/small_model_for_extraction.py
@@ -8,8 +8,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 llm = ChatOpenAI(model='gpt-4o', temperature=0.0)
 small_llm = ChatOpenAI(model='gpt-4o-mini', temperature=0.0)

--- a/examples/features/validate_output.py
+++ b/examples/features/validate_output.py
@@ -16,8 +16,8 @@ load_dotenv()
 
 from pydantic import BaseModel
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 controller = Controller()
 

--- a/examples/file_system/file_system.py
+++ b/examples/file_system/file_system.py
@@ -5,8 +5,8 @@ import shutil
 
 from dotenv import load_dotenv
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 load_dotenv()
 

--- a/examples/integrations/browserbase_stagehand.py
+++ b/examples/integrations/browserbase_stagehand.py
@@ -20,7 +20,7 @@ load_dotenv()
 
 from stagehand import Stagehand, StagehandConfig  # type: ignore
 
-from browser_use.agent.service import Agent
+from agentic_os.browser_use.agent.service import Agent
 
 
 async def main():

--- a/examples/integrations/discord/discord_api.py
+++ b/examples/integrations/discord/discord_api.py
@@ -10,9 +10,9 @@ load_dotenv()
 import discord  # type: ignore
 from discord.ext import commands  # type: ignore
 
-from browser_use.agent.service import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import BaseChatModel
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import BaseChatModel
 
 
 class DiscordBot(commands.Bot):
@@ -31,7 +31,7 @@ class DiscordBot(commands.Bot):
 
 	Usage:
 	    ```python
-	    from browser_use.llm import ChatOpenAI
+	    from agentic_os.browser_use.llm import ChatOpenAI
 
 	    llm = ChatOpenAI()
 	    bot = DiscordBot(llm=llm, prefix='$bu', ack=True)

--- a/examples/integrations/discord/discord_example.py
+++ b/examples/integrations/discord/discord_example.py
@@ -42,8 +42,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use.browser import BrowserProfile
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use.browser import BrowserProfile
+from agentic_os.browser_use.llm import ChatGoogle
 from examples.integrations.discord.discord_api import DiscordBot
 
 # load credentials from environment variables

--- a/examples/integrations/slack/slack_api.py
+++ b/examples/integrations/slack/slack_api.py
@@ -14,10 +14,10 @@ from slack_sdk.errors import SlackApiError  # type: ignore
 from slack_sdk.signature import SignatureVerifier  # type: ignore
 from slack_sdk.web.async_client import AsyncWebClient  # type: ignore
 
-from browser_use.agent.service import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import BaseChatModel
-from browser_use.logging_config import setup_logging
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import BaseChatModel
+from agentic_os.browser_use.logging_config import setup_logging
 
 setup_logging()
 logger = logging.getLogger('slack')

--- a/examples/integrations/slack/slack_example.py
+++ b/examples/integrations/slack/slack_example.py
@@ -8,8 +8,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use.browser import BrowserProfile
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use.browser import BrowserProfile
+from agentic_os.browser_use.llm import ChatGoogle
 from examples.integrations.slack.slack_api import SlackBot, app
 
 # load credentials from environment variables

--- a/examples/models/azure_openai.py
+++ b/examples/models/azure_openai.py
@@ -15,8 +15,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.llm import ChatAzureOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatAzureOpenAI
 
 # Retrieve Azure-specific environment variables
 azure_openai_api_key = os.getenv('AZURE_OPENAI_KEY')

--- a/examples/models/claude-4-sonnet.py
+++ b/examples/models/claude-4-sonnet.py
@@ -15,8 +15,8 @@ from lmnr import Laminar
 load_dotenv()
 Laminar.initialize()
 
-from browser_use import Agent
-from browser_use.llm import ChatAnthropic
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatAnthropic
 
 llm = ChatAnthropic(model='claude-4-sonnet-20250514', temperature=0.0)
 

--- a/examples/models/gemini.py
+++ b/examples/models/gemini.py
@@ -12,9 +12,9 @@ load_dotenv()
 Laminar.initialize()
 
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatGoogle
 
 api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:

--- a/examples/models/gpt-4.1.py
+++ b/examples/models/gpt-4.1.py
@@ -9,8 +9,8 @@ import asyncio
 from dotenv import load_dotenv
 from lmnr import Laminar
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 load_dotenv()
 

--- a/examples/models/llama4-groq.py
+++ b/examples/models/llama4-groq.py
@@ -13,8 +13,8 @@ load_dotenv()
 Laminar.initialize()
 
 
-from browser_use import Agent
-from browser_use.llm import ChatGroq
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatGroq
 
 groq_api_key = os.environ.get('GROQ_API_KEY')
 llm = ChatGroq(

--- a/examples/models/novita.py
+++ b/examples/models/novita.py
@@ -15,8 +15,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 api_key = os.getenv('NOVITA_API_KEY', '')
 if not api_key:

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import sys
 
-from browser_use.llm.openai.chat import ChatOpenAI
+from agentic_os.browser_use.llm.openai.chat import ChatOpenAI
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
+from agentic_os.browser_use import Agent
 
 # Initialize the model
 llm = ChatOpenAI(

--- a/examples/ui/command_line.py
+++ b/examples/ui/command_line.py
@@ -24,14 +24,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserSession
-from browser_use.controller.service import Controller
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.controller.service import Controller
 
 
 def get_llm(provider: str):
 	if provider == 'anthropic':
-		from browser_use.llm import ChatAnthropic
+		from agentic_os.browser_use.llm import ChatAnthropic
 
 		api_key = os.getenv('ANTHROPIC_API_KEY')
 		if not api_key:
@@ -39,7 +39,7 @@ def get_llm(provider: str):
 
 		return ChatAnthropic(model='claude-3-5-sonnet-20240620', temperature=0.0)
 	elif provider == 'openai':
-		from browser_use.llm import ChatOpenAI
+		from agentic_os.browser_use.llm import ChatOpenAI
 
 		api_key = os.getenv('OPENAI_API_KEY')
 		if not api_key:

--- a/examples/ui/gradio_demo.py
+++ b/examples/ui/gradio_demo.py
@@ -17,8 +17,8 @@ from rich.panel import Panel
 from rich.text import Text
 
 # Local module imports
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 @dataclass

--- a/examples/ui/streamlit_demo.py
+++ b/examples/ui/streamlit_demo.py
@@ -17,9 +17,9 @@ load_dotenv()
 
 import streamlit as st  # type: ignore
 
-from browser_use import Agent
-from browser_use.browser import BrowserSession
-from browser_use.controller.service import Controller
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.controller.service import Controller
 
 if os.name == 'nt':
 	asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
@@ -28,7 +28,7 @@ if os.name == 'nt':
 # Function to get the LLM based on provider
 def get_llm(provider: str):
 	if provider == 'anthropic':
-		from browser_use.llm import ChatAnthropic
+		from agentic_os.browser_use.llm import ChatAnthropic
 
 		api_key = os.getenv('ANTHROPIC_API_KEY')
 		if not api_key:
@@ -37,7 +37,7 @@ def get_llm(provider: str):
 
 		return ChatAnthropic(model='claude-3-5-sonnet-20240620', temperature=0.0)
 	elif provider == 'openai':
-		from browser_use.llm import ChatOpenAI
+		from agentic_os.browser_use.llm import ChatOpenAI
 
 		api_key = os.getenv('OPENAI_API_KEY')
 		if not api_key:

--- a/examples/use-cases/captcha.py
+++ b/examples/use-cases/captcha.py
@@ -18,8 +18,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/use-cases/check_appointment.py
+++ b/examples/use-cases/check_appointment.py
@@ -12,9 +12,9 @@ load_dotenv()
 
 from pydantic import BaseModel
 
-from browser_use.agent.service import Agent
-from browser_use.controller.service import Controller
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.controller.service import Controller
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/use-cases/find_and_apply_to_jobs.py
+++ b/examples/use-cases/find_and_apply_to_jobs.py
@@ -21,9 +21,9 @@ load_dotenv()
 from pydantic import BaseModel
 from PyPDF2 import PdfReader  # type: ignore
 
-from browser_use import ActionResult, Agent, Controller
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatAzureOpenAI
+from agentic_os.browser_use import ActionResult, Agent, Controller
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatAzureOpenAI
 
 required_env_vars = ['AZURE_OPENAI_KEY', 'AZURE_OPENAI_ENDPOINT']
 for var in required_env_vars:

--- a/examples/use-cases/find_influencer_profiles.py
+++ b/examples/use-cases/find_influencer_profiles.py
@@ -18,9 +18,9 @@ load_dotenv()
 import httpx
 from pydantic import BaseModel
 
-from browser_use import Agent, Controller
-from browser_use.agent.views import ActionResult
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.agent.views import ActionResult
+from agentic_os.browser_use.llm import ChatOpenAI
 
 
 class Profile(BaseModel):

--- a/examples/use-cases/google_sheets.py
+++ b/examples/use-cases/google_sheets.py
@@ -6,9 +6,9 @@ import asyncio
 
 from dotenv import load_dotenv
 
-from browser_use import Agent, Controller
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # Load environment variables
 load_dotenv()

--- a/examples/use-cases/online_coding_agent.py
+++ b/examples/use-cases/online_coding_agent.py
@@ -10,9 +10,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/use-cases/play_chess.py
+++ b/examples/use-cases/play_chess.py
@@ -20,10 +20,10 @@ import chess  # type: ignore
 from bs4 import BeautifulSoup
 from pydantic import BaseModel, Field
 
-from browser_use import Agent, Controller
-from browser_use.agent.views import ActionResult
-from browser_use.browser.context import BrowserContext
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.agent.views import ActionResult
+from agentic_os.browser_use.browser.context import BrowserContext
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/use-cases/post-twitter.py
+++ b/examples/use-cases/post-twitter.py
@@ -30,9 +30,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent, Controller
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent, Controller
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

--- a/examples/use-cases/scrolling_page.py
+++ b/examples/use-cases/scrolling_page.py
@@ -10,9 +10,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 if not os.getenv('OPENAI_API_KEY'):
 	raise ValueError('OPENAI_API_KEY is not set')

--- a/examples/use-cases/shopping.py
+++ b/examples/use-cases/shopping.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 task = """
    ### Prompt for Shopping Agent – Migros Online Grocery Order

--- a/examples/use-cases/twitter_post_using_cookies.py
+++ b/examples/use-cases/twitter_post_using_cookies.py
@@ -11,9 +11,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatGoogle
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatGoogle
 
 api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:

--- a/examples/use-cases/web_voyager_agent.py
+++ b/examples/use-cases/web_voyager_agent.py
@@ -12,9 +12,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-from browser_use.agent.service import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatAzureOpenAI, ChatOpenAI
+from agentic_os.browser_use.agent.service import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatAzureOpenAI, ChatOpenAI
 
 # Set LLM based on defined environment variables
 if os.getenv('OPENAI_API_KEY'):

--- a/examples/use-cases/wikipedia_banana_to_quantum.py
+++ b/examples/use-cases/wikipedia_banana_to_quantum.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent
-from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.llm import ChatOpenAI
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.browser import BrowserProfile, BrowserSession
+from agentic_os.browser_use.llm import ChatOpenAI
 
 # video https://preview.screen.studio/share/vuq91Ej8
 llm = ChatOpenAI(


### PR DESCRIPTION
## Summary
- add `agentic_os.browser_use` shim exposing the browser_use APIs
- update examples and docs to import from the new location
- mention the change in `migration-to-agentic-os.md`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: unrecognized arguments --dist=loadscope)*

------
https://chatgpt.com/codex/tasks/task_e_685d8398e970832998463d45e5ab3fce