### PR TITLE
Add OS tools with specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ async def main():
 asyncio.run(main())
 ```
 
+To enable OS helpers like running shell commands or listing directories,
+import `browser_use.tools_os` before creating the agent:
+
+```python
+import browser_use.tools_os  # registers OS tool specs
+```
+
 Add your API keys for the provider you want to use to your `.env` file.
 
 ```bash

--- a/browser_use/tools_os.py
+++ b/browser_use/tools_os.py
@@ -1,0 +1,137 @@
+"""Tool specifications for general OS operations."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from agentic_os import ToolSpec, register_spec
+from browser_use.agent.views import ActionResult
+
+
+class ShellCommandParams(BaseModel):
+    """Parameters for run_shell_command."""
+
+    command: str = Field(description="Command to execute in the shell")
+
+
+def run_shell_command(params: ShellCommandParams) -> ActionResult:
+    """Execute a shell command and return stdout/stderr."""
+    try:
+        completed = subprocess.run(
+            params.command, shell=True, check=False, capture_output=True, text=True
+        )
+        output = completed.stdout + completed.stderr
+        return ActionResult(extracted_content=output, include_in_memory=True)
+    except Exception as e:  # pragma: no cover - safeguard
+        return ActionResult(error=str(e), include_in_memory=True)
+
+
+class FilePathParams(BaseModel):
+    """Parameters for file path operations."""
+
+    path: str = Field(description="Path on the local filesystem")
+
+
+def read_file(params: FilePathParams) -> ActionResult:
+    """Read a file from disk."""
+    try:
+        with open(params.path, "r", encoding="utf-8") as f:
+            data = f.read()
+        return ActionResult(extracted_content=data, include_in_memory=True)
+    except Exception as e:  # pragma: no cover - simple wrapper
+        return ActionResult(error=str(e), include_in_memory=True)
+
+
+def list_directory(params: FilePathParams) -> ActionResult:
+    """List contents of a directory."""
+    try:
+        files = os.listdir(params.path)
+        return ActionResult(
+            extracted_content="\n".join(sorted(files)), include_in_memory=True
+        )
+    except Exception as e:  # pragma: no cover
+        return ActionResult(error=str(e), include_in_memory=True)
+
+
+class ManageProcessParams(BaseModel):
+    """Parameters for manage_process."""
+
+    action: str = Field(description="'start' or 'stop'")
+    command: Optional[str] = Field(None, description="Command to run when starting")
+    pid: Optional[int] = Field(None, description="PID of the process to stop")
+
+
+def manage_process(params: ManageProcessParams) -> ActionResult:
+    """Start or stop a process."""
+    try:
+        if params.action == "start" and params.command:
+            proc = subprocess.Popen(params.command, shell=True)
+            return ActionResult(
+                extracted_content=f"Started process {proc.pid}",
+                long_term_memory=str(proc.pid),
+                include_in_memory=True,
+            )
+        if params.action == "stop" and params.pid is not None:
+            os.kill(params.pid, signal.SIGTERM)
+            return ActionResult(
+                extracted_content=f"Stopped process {params.pid}",
+                include_in_memory=True,
+            )
+        return ActionResult(error="Invalid parameters", include_in_memory=True)
+    except Exception as e:  # pragma: no cover
+        return ActionResult(error=str(e), include_in_memory=True)
+
+
+# Register tool specifications -------------------------------------------------
+register_spec(
+    ToolSpec(
+        id="run_shell_command",
+        description="Run a shell command on the local OS and return output",
+        input_model=ShellCommandParams,
+        output_model=ActionResult,
+        func=run_shell_command,
+    )
+)
+
+register_spec(
+    ToolSpec(
+        id="read_os_file",
+        description="Read a file from the local OS",  # avoid collision with browser action
+        input_model=FilePathParams,
+        output_model=ActionResult,
+        func=read_file,
+    )
+)
+
+register_spec(
+    ToolSpec(
+        id="list_directory",
+        description="List contents of a directory on the local OS",
+        input_model=FilePathParams,
+        output_model=ActionResult,
+        func=list_directory,
+    )
+)
+
+register_spec(
+    ToolSpec(
+        id="manage_process",
+        description="Start or stop a process by pid or command",
+        input_model=ManageProcessParams,
+        output_model=ActionResult,
+        func=manage_process,
+    )
+)
+
+__all__ = [
+    "run_shell_command",
+    "read_file",
+    "list_directory",
+    "manage_process",
+]
+

--- a/examples/features/os_tools.py
+++ b/examples/features/os_tools.py
@@ -1,0 +1,25 @@
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import browser_use.tools_os  # registers OS tool specs
+from agentic_os.browser_use import Agent
+from agentic_os.browser_use.llm import ChatOpenAI
+
+
+async def main() -> None:
+    agent = Agent(
+        task="Run 'echo hello' using run_shell_command then list the current directory.",
+        llm=ChatOpenAI(model="gpt-4o"),
+    )
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/ci/test_os_tools_registry.py
+++ b/tests/ci/test_os_tools_registry.py
@@ -1,0 +1,36 @@
+import browser_use.tools_os  # register OS specs
+from agentic_os import get_registry
+from browser_use.tools_os import (
+    ShellCommandParams,
+    FilePathParams,
+    ManageProcessParams,
+)
+
+
+def test_os_tool_specs_registered():
+    registry = get_registry()
+    assert "run_shell_command" in registry
+    assert "read_os_file" in registry
+    assert "list_directory" in registry
+    assert "manage_process" in registry
+
+
+def test_os_tool_callable(tmp_path):
+    registry = get_registry()
+    run_cmd = registry["run_shell_command"].func
+    read_file = registry["read_os_file"].func
+    list_dir = registry["list_directory"].func
+
+    # create temp file
+    f = tmp_path / "example.txt"
+    f.write_text("hello")
+
+    # run shell command
+    result_cmd = run_cmd(ShellCommandParams(command="echo hi"))
+    assert "hi" in result_cmd.extracted_content
+
+    result_read = read_file(FilePathParams(path=str(f)))
+    assert result_read.extracted_content == "hello"
+
+    result_list = list_dir(FilePathParams(path=str(tmp_path)))
+    assert "example.txt" in result_list.extracted_content


### PR DESCRIPTION
## Summary
- introduce `tools_os` with ToolSpecs for shell commands, files and processes
- document enabling OS helpers in README
- add simple example showing OS tool usage
- test OS tool registration and basic functionality

## Testing
- `pytest -q tests/ci/test_os_tools_registry.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685d88ba2e4c8329a462608edfd6fe6f