### PR TITLE
Add LLMSyscallInterface

### DIFF
--- a/agentic_os/kernel/syscall.py
+++ b/agentic_os/kernel/syscall.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from agentic_os import get_registry
+from agentic_os.tools import ToolSpec
+from browser_use.llm.base import BaseChatModel
+
+
+class LLMSyscallInterface:
+	"""Simple syscall interface for interacting with LLMs and tools."""
+
+	def __init__(self, llm: BaseChatModel, registry: dict[str, ToolSpec] | None = None) -> None:
+		self._llm = llm
+		self._registry = registry or get_registry()
+
+	async def invoke_llm(self, messages: list[Any], output_model: type[BaseModel] | None = None) -> Any:
+		"""Invoke the underlying LLM with the given messages."""
+		assert isinstance(messages, list), 'messages must be a list'
+		return await self._llm.ainvoke(messages, output_model)
+
+	async def invoke_tool(self, tool_id: str, params: dict[str, Any] | BaseModel | None = None) -> Any:
+		"""Invoke a registered tool with validated parameters."""
+		if tool_id not in self._registry:
+		    raise ValueError(f'unknown tool {tool_id}')
+
+		spec = self._registry[tool_id]
+		if spec.func is None:
+		    raise ValueError(f'tool {tool_id} is missing callable')
+
+		if spec.input_model is not None:
+		    try:
+		        if isinstance(params, BaseModel):
+		            parsed = params
+		        else:
+		            parsed = spec.input_model.model_validate(params or {})
+		    except ValidationError as exc:
+		        raise exc
+		else:
+		    parsed = params
+
+		result = spec.func(parsed) if parsed is not None else spec.func()
+		if hasattr(result, '__await__'):
+		    return await result
+		return result

--- a/tests/ci/test_llm_syscall_interface.py
+++ b/tests/ci/test_llm_syscall_interface.py
@@ -1,0 +1,50 @@
+from pydantic import BaseModel
+from pytest import raises
+from unittest.mock import AsyncMock
+
+from agentic_os.kernel.syscall import LLMSyscallInterface
+from agentic_os.tools import ToolSpec
+
+
+class SimpleParams(BaseModel):
+	value: int
+
+
+async def test_invoke_llm_dispatch():
+	mock_llm = AsyncMock()
+	mock_llm.ainvoke.return_value = 'ok'
+	iface = LLMSyscallInterface(mock_llm, {})
+
+	result = await iface.invoke_llm(['hello'])
+
+	assert result == 'ok'
+	mock_llm.ainvoke.assert_awaited_once_with(['hello'], None)
+
+
+async def test_invoke_tool_dispatch():
+	async def tool(params: SimpleParams) -> int:
+		return params.value + 1
+
+	spec = ToolSpec('adder', 'add', SimpleParams, SimpleParams, tool)
+	iface = LLMSyscallInterface(AsyncMock(), {'adder': spec})
+
+	result = await iface.invoke_tool('adder', {'value': 1})
+
+	assert result == 2
+
+
+async def test_invoke_tool_unknown():
+	iface = LLMSyscallInterface(AsyncMock(), {})
+	with raises(ValueError):
+		await iface.invoke_tool('missing', {})
+
+
+async def test_invoke_tool_validation_error():
+	async def tool(params: SimpleParams) -> int:
+		return params.value
+
+	spec = ToolSpec('echo', 'echo', SimpleParams, SimpleParams, tool)
+	iface = LLMSyscallInterface(AsyncMock(), {'echo': spec})
+
+	with raises(Exception):
+		await iface.invoke_tool('echo', {'wrong': 1})


### PR DESCRIPTION
## Summary
- add kernel syscall interface for LLM and tool calls
- test syscall dispatch and errors

## Testing
- `uv run ruff format agentic_os/kernel/syscall.py`
- `uv run ruff format tests/ci/test_llm_syscall_interface.py`
- `uv run pyright`
- `uv run pytest -vxs tests/ci/test_llm_syscall_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_685d8bd51e188329ab7edb3ce9db74e9