### PR TITLE
Add managers for tools and access permissions

### DIFF
--- a/agentic_os/kernel/access.py
+++ b/agentic_os/kernel/access.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Iterable, Dict, Set
+
+import logging
+
+
+class AccessManager:
+	"""Simple permission manager that logs agent access events."""
+
+	def __init__(self, permissions: Dict[str, Iterable[str]] | None = None, logger: logging.Logger | None = None) -> None:
+		self._perms: Dict[str, Set[str]] = {k: set(v) for k, v in (permissions or {}).items()}
+		self._logger = logger or logging.getLogger(__name__)
+
+	def grant(self, agent_id: str, tool_id: str) -> None:
+		"""Allow ``agent_id`` to use ``tool_id``."""
+		self._perms.setdefault(agent_id, set()).add(tool_id)
+		self._logger.info("grant %s -> %s", agent_id, tool_id)
+
+	def revoke(self, agent_id: str, tool_id: str) -> None:
+		"""Revoke ``tool_id`` for ``agent_id``."""
+		if agent_id in self._perms:
+			self._perms[agent_id].discard(tool_id)
+		self._logger.info("revoke %s -> %s", agent_id, tool_id)
+
+	def is_allowed(self, agent_id: str, tool_id: str) -> bool:
+		"""Return whether ``agent_id`` may access ``tool_id``."""
+		allowed = tool_id in self._perms.get(agent_id, set())
+		self._logger.info("access %s -> %s : %s", agent_id, tool_id, allowed)
+		return allowed
+
+	def ensure_allowed(self, agent_id: str, tool_id: str) -> None:
+		"""Raise :class:`PermissionError` if ``agent_id`` lacks permission."""
+		if not self.is_allowed(agent_id, tool_id):
+			raise PermissionError(f"{agent_id} may not access {tool_id}")

--- a/agentic_os/kernel/tool.py
+++ b/agentic_os/kernel/tool.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Dict
+
+from pydantic import BaseModel
+
+from agentic_os.tools import ToolSpec
+
+
+class ToolManager:
+	"""Manage loading and execution of registered tools."""
+
+	def __init__(self, specs: Iterable[ToolSpec] | None = None) -> None:
+		self._registry: Dict[str, ToolSpec] = {}
+		if specs:
+			for spec in specs:
+				self.register(spec)
+
+	def register(self, spec: ToolSpec) -> None:
+		"""Register a :class:`ToolSpec`, checking for conflicts."""
+		if spec.id in self._registry:
+			existing = self._registry[spec.id]
+			if existing != spec:
+				raise ValueError(f'conflicting spec for {spec.id}')
+			return
+		self._registry[spec.id] = spec
+
+	def load_from(self, registry: Dict[str, ToolSpec]) -> None:
+		"""Load multiple specs from an existing registry."""
+		for spec in registry.values():
+			self.register(spec)
+
+	def get(self, tool_id: str) -> ToolSpec:
+		"""Return the spec for ``tool_id``."""
+		return self._registry[tool_id]
+
+	async def execute(self, tool_id: str, params: dict[str, Any] | BaseModel | None = None) -> Any:
+		"""Validate ``params`` using the tool's model and run it."""
+		spec = self.get(tool_id)
+		if spec.func is None:
+			raise ValueError(f'tool {tool_id} has no callable')
+
+		if spec.input_model is not None:
+			parsed = params if isinstance(params, BaseModel) else spec.input_model.model_validate(params or {})
+		else:
+			parsed = params
+
+		result = spec.func(parsed) if parsed is not None else spec.func()
+		if hasattr(result, '__await__'):
+			return await result
+		return result

--- a/tests/ci/test_access_manager.py
+++ b/tests/ci/test_access_manager.py
@@ -1,0 +1,22 @@
+from pytest import raises
+
+from agentic_os.kernel.access import AccessManager
+
+
+def test_basic_permissions(caplog):
+	mgr = AccessManager({"a": ["tool"]})
+	assert mgr.is_allowed("a", "tool")
+	assert not mgr.is_allowed("a", "other")
+
+	mgr.grant("a", "other")
+	assert mgr.is_allowed("a", "other")
+
+	mgr.revoke("a", "tool")
+	assert not mgr.is_allowed("a", "tool")
+
+
+def test_ensure_allowed():
+	mgr = AccessManager({"a": ["t"]})
+	mgr.ensure_allowed("a", "t")
+	with raises(PermissionError):
+		mgr.ensure_allowed("a", "x")

--- a/tests/ci/test_tool_manager.py
+++ b/tests/ci/test_tool_manager.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel
+from pytest import raises
+
+from agentic_os.kernel.tool import ToolManager
+from agentic_os.tools import ToolSpec
+
+
+class Params(BaseModel):
+	value: int
+
+
+async def add_one(params: Params) -> int:
+	return params.value + 1
+
+
+async def test_register_and_execute():
+	spec = ToolSpec("adder", "add one", Params, Params, add_one)
+	mgr = ToolManager([spec])
+
+	result = await mgr.execute("adder", {"value": 1})
+	assert result == 2
+
+
+async def test_conflict_detection():
+	spec1 = ToolSpec("t", "desc", Params, Params, add_one)
+	mgr = ToolManager([spec1])
+
+	async def other(params: Params) -> int:
+		return params.value
+
+	spec2 = ToolSpec("t", "desc", Params, Params, other)
+	with raises(ValueError):
+		mgr.register(spec2)


### PR DESCRIPTION
## Summary
- add `ToolManager` for resolving tool conflicts and running tools
- add `AccessManager` for per-agent permissions
- test the new managers

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest tests/ci/test_tool_manager.py tests/ci/test_access_manager.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685d93b95b5c83298b605c7a4e0010bd